### PR TITLE
Async camel route implementation deon for init worker

### DIFF
--- a/src/main/java/org/mifos/connector/slcb/camel/config/CamelProperties.java
+++ b/src/main/java/org/mifos/connector/slcb/camel/config/CamelProperties.java
@@ -14,4 +14,8 @@ public class CamelProperties {
     public static final String SLCB_RECONCILIATION_REQUEST = "slcbReconciliationRequest";
 
     public static final String SLCB_TRANSACTION_RESPONSE = "slcbTransactionResponse";
+
+    public static final String ZEEBE_JOB_KEY = "jobKey";
+
+    public static final String ZEEBE_VARIABLES = "zeebeVariables";
 }

--- a/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/TestRoutes.java
+++ b/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/TestRoutes.java
@@ -12,6 +12,8 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.*;
 
+import static org.mifos.connector.slcb.camel.config.CamelProperties.SLCB_CHANNEL_REQUEST;
+
 @Component
 public class TestRoutes extends RouteBuilder {
 
@@ -64,5 +66,10 @@ public class TestRoutes extends RouteBuilder {
                     String result = fileTransferService.uploadFile(file);
                     exchange.getIn().setBody(result);
                 });
+
+        from("rest:post:test/transferRequest")
+                .process(exchange -> exchange.setProperty(SLCB_CHANNEL_REQUEST, exchange.getIn().getBody(String.class)))
+                .to("direct:transfer-route")
+                .setBody(exchange -> exchange.getIn().getBody(String.class));
     }
 }

--- a/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/TransferResponseProcessor.java
+++ b/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/TransferResponseProcessor.java
@@ -8,14 +8,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
-
 import static org.mifos.connector.slcb.camel.config.CamelProperties.*;
-import static org.mifos.connector.slcb.zeebe.ZeebeVariables.TRANSFER_MESSAGE;
-import static org.mifos.connector.slcb.zeebe.ZeebeVariables.TRANSFER_RESPONSE;
 import static org.mifos.connector.slcb.zeebe.ZeebeVariables.TRANSFER_STATE;
 
 @Component

--- a/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/TransferRoutes.java
+++ b/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/TransferRoutes.java
@@ -8,14 +8,10 @@ import org.mifos.connector.slcb.dto.PaymentRequestDTO;
 import org.mifos.connector.slcb.utils.CsvUtils;
 import org.mifos.connector.slcb.utils.SLCBUtils;
 import org.mifos.connector.slcb.utils.SecurityUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 import java.io.File;
 import java.util.List;
 import java.util.UUID;
-
 import static org.mifos.connector.slcb.camel.config.CamelProperties.*;
 
 @Component

--- a/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/ZeebeCompleteCommandPublisher.java
+++ b/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/ZeebeCompleteCommandPublisher.java
@@ -3,7 +3,6 @@ package org.mifos.connector.slcb.camel.routes.transfer;
 import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;

--- a/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/ZeebeCompleteCommandPublisher.java
+++ b/src/main/java/org/mifos/connector/slcb/camel/routes/transfer/ZeebeCompleteCommandPublisher.java
@@ -1,0 +1,33 @@
+package org.mifos.connector.slcb.camel.routes.transfer;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static org.mifos.connector.slcb.camel.config.CamelProperties.ZEEBE_JOB_KEY;
+import static org.mifos.connector.slcb.camel.config.CamelProperties.ZEEBE_VARIABLES;
+
+@Component
+public class ZeebeCompleteCommandPublisher implements Processor {
+
+    private final ZeebeClient zeebeClient;
+
+    public ZeebeCompleteCommandPublisher(ZeebeClient zeebeClient) {
+        this.zeebeClient = zeebeClient;
+    }
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Map<String, Object> variables = (Map<String, Object>) exchange.getProperty(ZEEBE_VARIABLES);
+        Long jobKey = exchange.getProperty(ZEEBE_JOB_KEY, Long.class);
+
+        zeebeClient.newCompleteCommand(jobKey)
+                .variables(variables)
+                .send()
+                .join();
+    }
+}


### PR DESCRIPTION
This PR includes the below updates:
1. New processor implemented named `ZeebeCompleteCommandPublisher` for sending the zeebe client complete command.
2. Added reconciliation worker enum entry.
3. Update the existing `initiateTransfer` worker to support camel async send.
4. Updated the existing `TransferResponseProcessor` based on latest SLCB BPMN update.